### PR TITLE
remove reference to missing binary from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "2.0.0",
   "description": "Prepend data to a stream or file.",
   "main": "src/preface.js",
-  "bin": {
-    "preface": "bin/preface"
-  },
   "scripts": {
     "test": "ava",
     "start": "node ."


### PR DESCRIPTION
`npm install preface` currently fails because package.json is referencing a non-existant binary. This fixes that. Please accept and publish a new version of the package :)